### PR TITLE
EODHP-550 - pg_restore -> migrate.py loaddata - OLD PR - DELETE SOON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,6 @@ RUN apt-get install --yes --quiet --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &&\
     apt-get install -y nodejs
-RUN install -d /usr/share/postgresql-common/pgdg
-RUN curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
-RUN sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-RUN apt update
-RUN apt -y install postgresql
 
 RUN node -v
 RUN npm -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ RUN apt-get install --yes --quiet --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &&\
     apt-get install -y nodejs
+RUN install -d /usr/share/postgresql-common/pgdg
+RUN curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+RUN sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+RUN apt update
+RUN apt -y install postgresql
 
 RUN node -v
 RUN npm -v

--- a/eodhp_web_presence/database_dump.py
+++ b/eodhp_web_presence/database_dump.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     else:
         s3 = boto3.resource("s3")
 
-    output_file = f'{os.environ.get("ENV_NAME", "default")}-wagtail_dump-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.sql'  # noqa: E501
+    output_file = f'{os.environ.get("ENV_NAME", "default")}-wagtail_dump-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.json'  # noqa: E501
 
     with tempfile.NamedTemporaryFile() as tf:
         tf.name = output_file

--- a/eodhp_web_presence/database_dump.py
+++ b/eodhp_web_presence/database_dump.py
@@ -5,39 +5,8 @@ import subprocess
 import tempfile
 
 import boto3
-import psycopg2
-
-table_prefixes = ["home", "help", "wagtailimages"]
-
-pg_dump_path = "pg_dump"
 
 bucket_name = "web-database-exports"
-
-
-def get_tables() -> str:
-    conn = psycopg2.connect(
-        dbname=os.environ["SQL_DATABASE"],
-        user=os.environ["SQL_USER"],
-        password=os.environ["SQL_PASSWORD"],
-        host=os.environ["SQL_HOST"],
-        port=os.environ["SQL_PORT"],
-    )
-
-    cur = conn.cursor()
-
-    table_names = []
-
-    for prefix in table_prefixes:
-        cur.execute(
-            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE %s;",
-            (prefix + "%",),
-        )
-        table_names.extend([row[0] for row in cur.fetchall()])
-
-    cur.close()
-    conn.close()
-
-    return " ".join(f"-t {table}" for table in table_names)
 
 
 def update_file(path: str, s3_bucket_name: str, s3: boto3.resource) -> None:
@@ -61,19 +30,15 @@ if __name__ == "__main__":
     else:
         s3 = boto3.resource("s3")
 
-    tables_str = get_tables()
-
     output_file = f'{os.environ.get("ENV_NAME", "default")}-wagtail_dump-{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.sql'  # noqa: E501
 
     with tempfile.NamedTemporaryFile() as tf:
         tf.name = output_file
 
-        command = f'{pg_dump_path} -U {os.environ["SQL_USER"]} -h {os.environ["SQL_HOST"]} -p {os.environ["SQL_PORT"]} -d {os.environ["SQL_DATABASE"]} {tables_str} -F c -f {output_file}'  # noqa: E501
+        command = f"python manage.py dumpdata home wagtailimages wagtailcore --natural-primary --natural-foreign --exclude auth --exclude contenttypes --exclude sessions > {output_file}"  # noqa: E501
 
         logging.info(f"Running: {command}")
-        os.environ["PGPASSWORD"] = os.environ["SQL_PASSWORD"]
         subprocess.run(command, shell=True, check=True)
-        del os.environ["PGPASSWORD"]
 
         logging.info(f"Updating {output_file} into {bucket_name}")
         update_file(output_file, bucket_name, s3)

--- a/eodhp_web_presence/database_load.py
+++ b/eodhp_web_presence/database_load.py
@@ -40,7 +40,7 @@ def truncate_tables() -> str:
                 conn.commit()
             except psycopg2.errors.UndefinedTable:
                 logging.info(
-                    f"Error truncating {table} - check that it exists and consider deleting unused table from original database"
+                    f"Error truncating {table} - check that it exists and consider deleting unused table from original database"  # noqa: E501
                 )
                 conn.rollback()
 

--- a/eodhp_web_presence/database_load.py
+++ b/eodhp_web_presence/database_load.py
@@ -7,7 +7,7 @@ import tempfile
 import boto3
 import psycopg2
 
-table_prefixes = ["home", "help", "wagtailimages", "wagtailcore"]
+table_prefixes = ["home", "wagtailimages", "wagtailcore"]
 
 bucket_name = "web-database-exports"
 
@@ -27,8 +27,8 @@ def truncate_tables() -> str:
 
     for prefix in table_prefixes:
         cur.execute(
-            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE %s;",
-            (prefix + "%",),
+            "SELECT tablename FROM pg_tables WHERE schemaname = %s AND tablename LIKE %s;",
+            (os.environ["ENV_NAME"], prefix + "%",),
         )
         table_names.extend([row[0] for row in cur.fetchall()])
 

--- a/eodhp_web_presence/database_load.py
+++ b/eodhp_web_presence/database_load.py
@@ -5,12 +5,47 @@ import sys
 import tempfile
 
 import boto3
+import psycopg2
 
-table_prefixes = ["home", "help", "wagtailimages"]
-
-pg_load_path = "pg_restore"
+table_prefixes = ["home", "help", "wagtailimages", "wagtailcore"]
 
 bucket_name = "web-database-exports"
+
+
+def truncate_tables() -> str:
+    conn = psycopg2.connect(
+        dbname=os.environ["SQL_DATABASE"],
+        user=os.environ["SQL_USER"],
+        password=os.environ["SQL_PASSWORD"],
+        host=os.environ["SQL_HOST"],
+        port=os.environ["SQL_PORT"],
+    )
+
+    cur = conn.cursor()
+
+    table_names = []
+
+    for prefix in table_prefixes:
+        cur.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE %s;",
+            (prefix + "%",),
+        )
+        table_names.extend([row[0] for row in cur.fetchall()])
+
+    for table in table_names:
+        if not table == "wagtailcore_locale":
+            logging.info(f"Truncating {table}")
+            try:
+                cur.execute(f"TRUNCATE TABLE {table} CASCADE;")
+                conn.commit()
+            except psycopg2.errors.UndefinedTable:
+                logging.info(
+                    f"Error truncating {table} - check that it exists and consider deleting unused table from original database"
+                )
+                conn.rollback()
+
+    cur.close()
+    conn.close()
 
 
 if __name__ == "__main__":
@@ -38,11 +73,11 @@ if __name__ == "__main__":
         logging.info(f"Collecting {file} from {bucket_name}")
         s3.download_file(bucket_name, file, f"{tmpdir}/{file}")
 
-        command = f'{pg_load_path} -c -U {os.environ["SQL_USER"]} -h {os.environ["SQL_HOST"]} -p {os.environ["SQL_PORT"]} -d {os.environ["SQL_DATABASE"]} < {tmpdir}/{file}'  # noqa: E501
+        truncate_tables()
+
+        command = f"python manage.py loaddata {tmpdir}/{file}"
 
         logging.info(f"Running: {command}")
-        os.environ["PGPASSWORD"] = os.environ["SQL_PASSWORD"]
         subprocess.run(command, shell=True, check=True)
-        del os.environ["PGPASSWORD"]
 
         logging.info("Complete")

--- a/eodhp_web_presence/database_load.py
+++ b/eodhp_web_presence/database_load.py
@@ -28,7 +28,10 @@ def truncate_tables() -> str:
     for prefix in table_prefixes:
         cur.execute(
             "SELECT tablename FROM pg_tables WHERE schemaname = %s AND tablename LIKE %s;",
-            (os.environ["ENV_NAME"], prefix + "%",),
+            (
+                os.environ["ENV_NAME"],
+                prefix + "%",
+            ),
         )
         table_names.extend([row[0] for row in cur.fetchall()])
 


### PR DESCRIPTION
For moving content between two databases. May break references.

Not for use on a new, empty database but is likely to save a lot of time when updating multiple clusters with the same information at the same time