### PR TITLE
added support for defining postgres schema

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -3,12 +3,7 @@ on:
   workflow_call:
   push:
     tags:
-      - "v[0-9]+"
-      - "v[0-9]+-*"
-      - "v[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+-*"
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
+      - v[0-9]+*
     branches:
       - "**"
 
@@ -43,17 +38,15 @@ jobs:
           echo $IMAGE_TAG
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
-  aws-ecr-build:
-    name: Build ECR image
-    needs: get-tag-name
-    uses: EO-DataHub/github-actions/.github/workflows/docker-image-to-aws-ecr.yaml@main
+  publish:
+    name: Build and push Docker image
+    needs: [get-tag-name]
+    uses: EO-DataHub/github-actions/.github/workflows/ecr-publish.yaml@main
     with:
-      image_name: eodhp-web-presence
+      image_name: ${{ vars.IMAGE_NAME }}
       image_tag: ${{ needs.get-tag-name.outputs.image_tag }}
+      aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+      aws_ecr_alias: ${{ vars.AWS_ECR_ALIAS }}
     permissions:
       id-token: write
       contents: read
-    secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      AWS_ECR: ${{ secrets.AWS_ECR }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: dockerbuild dockerpush test testonce ruff black lint isort pre-commit-check requirements-update requirements setup
-VERSION ?= 0.1.25
+VERSION ?= 0.1.26
 IMAGENAME = eodhp-web-presence
-DOCKERREPO ?= public.ecr.aws/n1b3o1k2
+DOCKERREPO ?= public.ecr.aws/eodh
 
 dockerbuild:
 	pip-compile --output-file=requirements.txt -U

--- a/eodhp_web_presence/eodhp_web_presence/settings.py
+++ b/eodhp_web_presence/eodhp_web_presence/settings.py
@@ -173,6 +173,12 @@ DATABASES = {
     }
 }
 
+# Support schema definition for Postgres
+if DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":
+    DATABASES["default"]["OPTIONS"] = {
+        "options": f"-c search_path={env('SQL_SCHEMA', default='public')}",
+    }
+
 RESOURCE_CATALOGUE = {
     "version": env("RESOURCE_CATALOGUE_VERSION", default="v1.0.0"),
     "url": env("RESOURCE_CATALOGUE_URL", default=None),
@@ -277,9 +283,7 @@ WAGTAILADMIN_BASE_URL = env("BASE_URL", default="www.example.com")
 SECRET_KEY = env("SECRET_KEY", default="None")
 
 # SECURITY WARNING: define the correct hosts in production!
-ALLOWED_HOSTS = [
-    host.strip() for host in env("ALLOWED_HOSTS", default="localhost, 127.0.0.1").split(",")
-]
+ALLOWED_HOSTS = [host.strip() for host in env("ALLOWED_HOSTS", default="localhost, 127.0.0.1").split(",")]
 
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 

--- a/eodhp_web_presence/eodhp_web_presence/settings.py
+++ b/eodhp_web_presence/eodhp_web_presence/settings.py
@@ -283,7 +283,9 @@ WAGTAILADMIN_BASE_URL = env("BASE_URL", default="www.example.com")
 SECRET_KEY = env("SECRET_KEY", default="None")
 
 # SECURITY WARNING: define the correct hosts in production!
-ALLOWED_HOSTS = [host.strip() for host in env("ALLOWED_HOSTS", default="localhost, 127.0.0.1").split(",")]
+ALLOWED_HOSTS = [
+    host.strip() for host in env("ALLOWED_HOSTS", default="localhost, 127.0.0.1").split(",")
+]
 
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,17 +10,17 @@ asgiref==3.8.1
     # via django
 beautifulsoup4==4.11.2
     # via wagtail
-black==24.10.0
+black==25.1.0
     # via eodhp-website (pyproject.toml)
-boto3==1.36.4
+boto3==1.36.12
     # via eodhp-website (pyproject.toml)
-botocore==1.36.4
+botocore==1.36.12
     # via
     #   boto3
     #   s3transfer
 build==1.2.2.post1
     # via pip-tools
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -88,7 +88,7 @@ idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
-isort==5.13.2
+isort==6.0.0
     # via eodhp-website (pyproject.toml)
 jinja2==3.1.5
     # via eodhp-website (pyproject.toml)
@@ -156,7 +156,7 @@ pytest-xdist==3.6.1
     # via eodhp-website (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
-pytz==2024.2
+pytz==2025.1
     # via l18n
 pyyaml==6.0.2
     # via
@@ -164,9 +164,9 @@ pyyaml==6.0.2
     #   pre-commit
 requests==2.32.3
     # via wagtail
-ruff==0.9.2
+ruff==0.9.4
     # via eodhp-website (pyproject.toml)
-s3transfer==0.11.1
+s3transfer==0.11.2
     # via boto3
 six==1.17.0
     # via
@@ -189,7 +189,7 @@ validate-pyproject[all]==0.23
     # via eodhp-website (pyproject.toml)
 virtualenv==20.29.1
     # via pre-commit
-wagtail==5.2.7
+wagtail==5.2.8
     # via
     #   eodhp-website (pyproject.toml)
     #   wagtail-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ asgiref==3.8.1
     # via django
 beautifulsoup4==4.11.2
     # via wagtail
-boto3==1.36.4
+boto3==1.36.12
     # via eodhp-website (pyproject.toml)
-botocore==1.36.4
+botocore==1.36.12
     # via
     #   boto3
     #   s3transfer
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -90,11 +90,11 @@ pyjwt==2.10.1
     # via eodhp-website (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
-pytz==2024.2
+pytz==2025.1
     # via l18n
 requests==2.32.3
     # via wagtail
-s3transfer==0.11.1
+s3transfer==0.11.2
     # via boto3
 six==1.17.0
     # via
@@ -111,7 +111,7 @@ urllib3==2.3.0
     # via
     #   botocore
     #   requests
-wagtail==5.2.7
+wagtail==5.2.8
     # via
     #   eodhp-website (pyproject.toml)
     #   wagtail-cache


### PR DESCRIPTION
There is a race condition when creating a new cluster where if the schema is not specifically requested in an app then it will use the public schema if the db migrations runs before the database user config job to set the default search_path. I added support for defining postgres search path.

I also updated makefile to point to new ECR repo, but have not yet updated the github repo env vars to point to the new ECR.