### PR TITLE
Skip formatting of migrations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,6 @@ ignore = [
 "**/tests/*.py" = ["ANN"]
 "**/test_*.py" = ["ANN"]
 "**/settings.py" = ["SIM105", "F403"]
+
+[tool.ruff.format]
+exclude = ["**/migrations/*.py"]


### PR DESCRIPTION
Change of one single field reformats it to sometimes even 4k+ files